### PR TITLE
Use the configured mailer implementation in development environments

### DIFF
--- a/src/main/java/br/com/caelum/vraptor/simplemail/MailerFactory.java
+++ b/src/main/java/br/com/caelum/vraptor/simplemail/MailerFactory.java
@@ -35,9 +35,6 @@ public class MailerFactory  {
 	}
 
 	private Mailer grabInstance() {
-		if (env.getName().equals("development")) {
-			return new MockMailer();
-		}
 		try {
 			return instantiateWithEnv();
 		} catch (Exception e) {

--- a/src/test/java/br/com/caelum/vraptor/simplemail/MailerFactoryTest.java
+++ b/src/test/java/br/com/caelum/vraptor/simplemail/MailerFactoryTest.java
@@ -63,7 +63,7 @@ public class MailerFactoryTest {
 		assertThat(mailerWithEnv.getMyEnv(), equalTo(env));
 	}
 	
-	@Test @Ignore
+	@Test
 	public void should_create_mailer_from_properties_if_specified_and_in_development() throws Exception {
 		when(env.getName()).thenReturn("development");
 		when(env.has(MailerFactory.MAILER_IMPLEMENTATION)).thenReturn(true);


### PR DESCRIPTION
In master commit 31970efa6ce701f1fb873448616898574d03f2f6 makes it
possible to select a mailer implementation via the mailer.implementation
property in the environment configuration file. A small "if" prevents
this from working in the VRaptor4Version branch.
